### PR TITLE
Add alternate language code for Norwegian Bokmål

### DIFF
--- a/frontend/src/Language.tsx
+++ b/frontend/src/Language.tsx
@@ -18,6 +18,7 @@
 export interface Language {
   label: string;
   value: string;
+  pageCode?: string;
 }
 
 export default Language;

--- a/frontend/src/LanguageList.tsx
+++ b/frontend/src/LanguageList.tsx
@@ -108,7 +108,8 @@ export const top50Languages : Language[] = [
   },
   {
     "label": "Norwegian (Bokmål)",
-    "value": "no"
+    "value": "nb",
+    "pageCode": "no"
   },
   {
     "label": "Korean",
@@ -307,7 +308,8 @@ export const languages : Language[] = [
   },
   {
     "label": "Norwegian (Bokmål)",
-    "value": "no"
+    "value": "nb",
+    "pageCode": "no"
   },
   {
     "label": "Korean",

--- a/frontend/src/WikiApi.tsx
+++ b/frontend/src/WikiApi.tsx
@@ -141,7 +141,7 @@ export class WikiApi {
   }
 
   private searchPages(language: Language, search : string) : Promise<Page[]> {
-    let wikiUrl = 'https://' + language.value + '.wikipedia.org';
+    let wikiUrl = this.getWikiUrl(language);
     let apiUrl = wikiUrl + '/w/api.php';
     let options = this.baseOptions + '&action=query&list=search';
     return fetch(apiUrl + options + '&srsearch=' + search)
@@ -167,7 +167,7 @@ export class WikiApi {
   }
 
   private getExtraPageInfo(language : Language, title : string) {
-    let wikiUrl = 'https://' + language.value + '.wikipedia.org';
+    let wikiUrl = this.getWikiUrl(language);
     let apiUrl = wikiUrl + '/w/api.php';
     this.searchPage(language, title)
       .then(page => {
@@ -237,7 +237,7 @@ export class WikiApi {
       return this.getExtraPageInfo(outLang, title);
     }
 
-    let inApiUrl = 'https://' + inLang.value + '.wikipedia.org';
+    let inApiUrl = this.getWikiUrl(inLang);
     return this.getDifferentLangTitles(inApiUrl, title)
                .then(langTitles => {
                  let correct = langTitles.find(lt => lt.language.value === outLang.value);
@@ -256,7 +256,7 @@ export class WikiApi {
   private findThumbnailForPage(
     page: Page,
     callback: (p : Page) => void) {
-    let wikiUrl = 'https://' + page.languages[0].value + '.wikipedia.org';
+    let wikiUrl = this.getWikiUrl(page.languages[0]);
     let apiUrl = wikiUrl + '/w/api.php';
     return this.getImage(apiUrl, page.title, true)
       .then(imageUrl => {
@@ -271,6 +271,12 @@ export class WikiApi {
     pages: Page[],
     callback: (p : Page) => void) {
     pages.map(p => this.findThumbnailForPage(p, callback));
+  }
+
+  private getWikiUrl(language: Language) {
+    const wikiUrl = 'https://' + (language.pageCode ?? language.value) + '.wikipedia.org';
+    
+    return wikiUrl;
   }
 }
 


### PR DESCRIPTION
The Wikipedia website and the Wikipedia API use two different language codes for the Norwegian Bokmål language, namely "no" and "nb" respectively. 
The correct language code is "nb", but the URLs on the Wikipedia website use the _legacy_ "no" language code. 

This causes translations from any language to Norwegian Bokmål to never succeed because it sends the language code "no" to the Wikipedia API which doesn't recognize it; it only works with "nb". 

This PR changes the language code from "no" to "nb" and adds an alternate "pageCode" value for the Norwegian Bokmål language to be used when building Wikipedia URLs. 